### PR TITLE
add cleanup snapshot and backup meta logical

### DIFF
--- a/cmd/backup-manager/app/clean/clean.go
+++ b/cmd/backup-manager/app/clean/clean.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"time"
 
@@ -79,6 +80,9 @@ func (bo *Options) deleteSnapshotsAndBackupMeta(ctx context.Context, backup *v1a
 	if err := bo.copyRemoteBackupMetaToLocal(ctx, backup.Status.BackupPath, opts); err != nil {
 		klog.Errorf("rclone copy remote backupmeta to local failure.")
 	}
+	defer func() {
+		_ = os.Remove(metaFile)
+	}()
 
 	contents, err := ioutil.ReadFile(metaFile)
 	if err != nil {
@@ -101,6 +105,7 @@ func (bo *Options) deleteSnapshotsAndBackupMeta(ctx context.Context, backup *v1a
 	if err = bo.cleanRemoteBackupData(ctx, backup.Status.BackupPath, opts); err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/cmd/backup-manager/app/util/aws_ebs.go
+++ b/cmd/backup-manager/app/util/aws_ebs.go
@@ -1,0 +1,135 @@
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
+
+package util
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/pingcap/errors"
+	"go.uber.org/atomic"
+	"golang.org/x/sync/errgroup"
+	"k8s.io/klog/v2"
+)
+
+// TODO: shall this structure be refactor or reserved for future use?
+type EBSVolumeType string
+
+const (
+	GP3Volume EBSVolumeType = "gp3"
+	IO1Volume               = "io1"
+	IO2Volume               = "io2"
+)
+
+func (t EBSVolumeType) Valid() bool {
+	return t == GP3Volume || t == IO1Volume || t == IO2Volume
+}
+
+// EBSVolume is passed by TiDB deployment tools: TiDB Operator and TiUP(in future)
+// we should do snapshot inside BR, because we need some logic to determine the order of snapshot starts.
+// TODO finish the info with TiDB Operator developer.
+type EBSVolume struct {
+	ID              string `json:"volume_id" toml:"volume_id"`
+	Type            string `json:"type" toml:"type"`
+	SnapshotID      string `json:"snapshot_id" toml:"snapshot_id"`
+	RestoreVolumeId string `json:"restore_volume_id" toml:"restore_volume_id"`
+	VolumeAZ        string `json:"volume_az" toml:"volume_az"`
+	Status          string `json:"status" toml:"status"`
+}
+
+type EBSStore struct {
+	StoreID uint64       `json:"store_id" toml:"store_id"`
+	Volumes []*EBSVolume `json:"volumes" toml:"volumes"`
+}
+
+// ClusterInfo represents the tidb cluster level meta infos. such as
+// pd cluster id/alloc id, cluster resolved ts and tikv configuration.
+type ClusterInfo struct {
+	Version        string            `json:"cluster_version" toml:"cluster_version"`
+	FullBackupType string            `json:"full_backup_type" toml:"full_backup_type"`
+	ResolvedTS     uint64            `json:"resolved_ts" toml:"resolved_ts"`
+	Replicas       map[string]uint64 `json:"replicas" toml:"replicas"`
+}
+
+type Kubernetes struct {
+	PVs     []interface{}          `json:"pvs" toml:"pvs"`
+	PVCs    []interface{}          `json:"pvcs" toml:"pvcs"`
+	CRD     interface{}            `json:"crd_tidb_cluster" toml:"crd_tidb_cluster"`
+	Options map[string]interface{} `json:"options" toml:"options"`
+}
+
+type TiKVComponent struct {
+	Replicas int         `json:"replicas"`
+	Stores   []*EBSStore `json:"stores"`
+}
+
+type PDComponent struct {
+	Replicas int `json:"replicas"`
+}
+
+type TiDBComponent struct {
+	Replicas int `json:"replicas"`
+}
+
+type EBSBasedBRMeta struct {
+	ClusterInfo    *ClusterInfo           `json:"cluster_info" toml:"cluster_info"`
+	TiKVComponent  *TiKVComponent         `json:"tikv" toml:"tikv"`
+	TiDBComponent  *TiDBComponent         `json:"tidb" toml:"tidb"`
+	PDComponent    *PDComponent           `json:"pd" toml:"pd"`
+	KubernetesMeta *Kubernetes            `json:"kubernetes" toml:"kubernetes"`
+	Options        map[string]interface{} `json:"options" toml:"options"`
+	Region         string                 `json:"region" toml:"region"`
+}
+
+type EC2Session struct {
+	ec2 ec2iface.EC2API
+	// aws operation concurrency
+	concurrency uint
+}
+
+type VolumeAZs map[string]string
+
+func NewEC2Session(concurrency uint) (*EC2Session, error) {
+	// aws-sdk has builtin exponential backoff retry mechanism, see:
+	// https://github.com/aws/aws-sdk-go/blob/db4388e8b9b19d34dcde76c492b17607cd5651e2/aws/client/default_retryer.go#L12-L16
+	// with default retryer & max-retry=9, we will wait for at least 30s in total
+	awsConfig := aws.NewConfig().WithMaxRetries(9)
+	// TiDB Operator need make sure we have the correct permission to call aws api(through aws env variables)
+	// we may change this behaviour in the future.
+	sessionOptions := session.Options{Config: *awsConfig}
+	sess, err := session.NewSessionWithOptions(sessionOptions)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ec2Session := ec2.New(sess)
+	return &EC2Session{ec2: ec2Session, concurrency: concurrency}, nil
+}
+
+func (e *EC2Session) DeleteSnapshots(snapIDMap map[string]string) error {
+
+	var deletedCnt atomic.Int32
+	eg := new(errgroup.Group)
+	for volID := range snapIDMap {
+		snapID := snapIDMap[volID]
+		eg.Go(func() error {
+			_, err := e.ec2.DeleteSnapshot(&ec2.DeleteSnapshotInput{
+				SnapshotId: &snapID,
+			})
+			if err != nil {
+				klog.Errorf("failed to delete snapshot id=%s, error=%s", snapID, err)
+				// todo: we can only retry for a few times, might fail still, need to handle error from outside.
+				// we don't return error if it fails to make sure all snapshot got chance to delete.
+			} else {
+				deletedCnt.Add(1)
+			}
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		klog.Errorf("failed to delete snapshots error=%s, already delete=%d", err, deletedCnt.Load())
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
### What problem does this PR solve?
adapts the current TiDB-Operator to support cleanup the EBS backup cleanup

### What is changed and how does it work?
1. for volume-snapshot backup, rclone copy the backup meta to local
2. read the backup meta, get all the snapshots ID
3. delete the snapshots ID
4. remove the backup meta
### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
